### PR TITLE
fix(insights): thin map and time-series prompts, lower budget cap

### DIFF
--- a/frontend/src/cards/CardWrapper.tsx
+++ b/frontend/src/cards/CardWrapper.tsx
@@ -67,8 +67,9 @@ function CardWrapper(props: {
   fips?: Fips
   dataTypeConfig?: DataTypeConfig
   demographicType?: DemographicType
-  // The demographic group currently highlighted on a map. Steers the insight
-  // prompt so it leads with that group's story.
+  // The demographic group currently highlighted on a map. On a multi-place
+  // map this both filters the insight data to that group and steers the
+  // prompt to lead with it; on a single-place map it's used for wording only.
   activeDemographicGroup?: DemographicGroup
   // The subset of groups the user has focused a trend chart on (via the legend).
   // Filters the insight data so it describes only the visible lines.
@@ -156,6 +157,7 @@ function CardWrapper(props: {
                 queryResponses,
                 insightProps.selectedGroups,
                 Boolean(regionRate),
+                insightProps.activeDemographicGroup,
               )
             : 'empty'
         const showInsight =

--- a/frontend/src/utils/generateVisualizationInsight.test.ts
+++ b/frontend/src/utils/generateVisualizationInsight.test.ts
@@ -59,6 +59,74 @@ describe('formatDataRows', () => {
     )
   })
 
+  test('a multi-place map defaults to the active demographic group plus each place\'s "All" baseline', () => {
+    const rows: HetRow[] = [
+      { fips_name: 'Alabama', race_and_ethnicity: 'All', rate: 9 },
+      { fips_name: 'Alabama', race_and_ethnicity: 'Black (NH)', rate: 12 },
+      { fips_name: 'Alabama', race_and_ethnicity: 'White (NH)', rate: 6 },
+      { fips_name: 'Alaska', race_and_ethnicity: 'All', rate: 5 },
+      { fips_name: 'Alaska', race_and_ethnicity: 'Black (NH)', rate: 7 },
+      { fips_name: 'Alaska', race_and_ethnicity: 'White (NH)', rate: 4 },
+    ]
+    const result = formatDataRows(
+      rows,
+      'rate-map',
+      DEMO,
+      metricConfig,
+      undefined,
+      'Black (NH)',
+    )
+    expect(result).toEqual(
+      '- Alabama (All): 9 per 100k\n' +
+        '- Alabama (Black (NH)): 12 per 100k\n' +
+        '- Alaska (All): 5 per 100k\n' +
+        '- Alaska (Black (NH)): 7 per 100k',
+    )
+  })
+
+  test('an active group of "All" on a multi-place map sends every group', () => {
+    const rows: HetRow[] = [
+      { fips_name: 'Alabama', race_and_ethnicity: 'All', rate: 9 },
+      { fips_name: 'Alabama', race_and_ethnicity: 'Black (NH)', rate: 12 },
+      { fips_name: 'Alaska', race_and_ethnicity: 'All', rate: 5 },
+    ]
+    const result = formatDataRows(
+      rows,
+      'rate-map',
+      DEMO,
+      metricConfig,
+      undefined,
+      'All',
+    )
+    expect(result.split('\n')).toHaveLength(3)
+  })
+
+  test('a single-place map falls back to every group in that place, ignoring the active group filter', () => {
+    const rows: HetRow[] = [
+      { fips_name: 'Gwinnett County', race_and_ethnicity: 'All', rate: 7.3 },
+      {
+        fips_name: 'Gwinnett County',
+        race_and_ethnicity: 'Black (NH)',
+        rate: 8.7,
+      },
+      {
+        fips_name: 'Gwinnett County',
+        race_and_ethnicity: 'White (NH)',
+        rate: 6.6,
+      },
+    ]
+    const result = formatDataRows(
+      rows,
+      'rate-map',
+      DEMO,
+      metricConfig,
+      undefined,
+      'Black (NH)',
+    )
+    expect(result.split('\n')).toHaveLength(3)
+    expect(result).toContain('- Gwinnett County (All): 7.3 per 100k')
+  })
+
   test('non-map charts label rows by demographic group alone', () => {
     const rows: HetRow[] = [
       { race_and_ethnicity: 'Black (NH)', rate: 9 },
@@ -92,6 +160,32 @@ describe('formatDataRows', () => {
     ]
     expect(formatDataRows(rows, 'rates-over-time', DEMO, metricConfig)).toEqual(
       '- Black (NH) (2010): 5 per 100k\n- White (NH) (2010): 3 per 100k',
+    )
+  })
+
+  test('a short time series is sent in full, not just first/last', () => {
+    const rows: HetRow[] = Array.from({ length: 10 }, (_, i) => ({
+      race_and_ethnicity: 'Black (NH)',
+      time_period: `${2010 + i}`,
+      rate: i,
+    }))
+    const result = formatDataRows(rows, 'rates-over-time', DEMO, metricConfig)
+    expect(result.split('\n')).toHaveLength(10)
+  })
+
+  test('a time series too large for the prompt budget is thinned but keeps the true first and last point', () => {
+    const rows: HetRow[] = Array.from({ length: 400 }, (_, i) => ({
+      race_and_ethnicity: 'Black (NH)',
+      time_period: `${1917 + i}`,
+      rate: i,
+    }))
+    const result = formatDataRows(rows, 'rates-over-time', DEMO, metricConfig)
+    const lines = result.split('\n')
+    expect(lines.length).toBeLessThan(400)
+    expect(lines[0]).toEqual('- Black (NH) (1917): 0 per 100k')
+    expect(lines[lines.length - 1]).toEqual('- Black (NH) (2316): 399 per 100k')
+    expect(new TextEncoder().encode(result).length).toBeLessThanOrEqual(
+      12 * 1024,
     )
   })
 })

--- a/frontend/src/utils/generateVisualizationInsight.ts
+++ b/frontend/src/utils/generateVisualizationInsight.ts
@@ -28,10 +28,16 @@ const MAP_CHART_IDS: ScrollableHashId[] = [
   'unknown-demographic-map',
   'multimap-modal',
 ]
+
 const TIME_SERIES_CHART_IDS: ScrollableHashId[] = [
   'rates-over-time',
   'inequities-over-time',
 ]
+
+// Per-side data-section budget for time series. Compare mode sends two of
+// these in one prompt, so this is set well under half the server's prompt
+// cap (server/insight_budget.go) to leave room for scaffold text on both sides.
+const TIME_SERIES_TARGET_BYTES = 12 * 1024
 
 // Select the most relevant metric config for the given chart type
 export function getPrimaryMetricConfig(
@@ -56,6 +62,13 @@ export function formatDataRows(
   // groups, restrict the rows to those groups so the insight describes only
   // what is on screen. Empty/undefined means "all groups".
   selectedGroups?: DemographicGroup[],
+  // The demographic group currently highlighted on a map. When the map is
+  // showing multiple places (a real geographic comparison), default to only
+  // this group's rows across places, since that's what's on screen and it
+  // keeps the prompt small. When only one place is in view, there's no
+  // geographic comparison to make, so send every group for that one place
+  // instead (the ALL-groups-within-place fallback).
+  activeDemographicGroup?: DemographicGroup,
 ): string {
   const isMap = MAP_CHART_IDS.includes(hashId)
   const isTimeSeries = TIME_SERIES_CHART_IDS.includes(hashId)
@@ -65,35 +78,67 @@ export function formatDataRows(
       : null
 
   if (isTimeSeries) {
-    // Group by demographic subgroup, then show the first and most recent year per group
-    // so the model can describe the full trend arc (e.g. "fell from X in 2008 to Y in 2021")
+    // Group by demographic subgroup and sort each group's points chronologically.
     const byGroup: Record<string, HetRow[]> = {}
     for (const row of rows) {
       const group = String(row[demographicType] ?? 'Unknown')
       if (groupFilter && !groupFilter.has(group)) continue
+      if (row[metricConfig.metricId] == null) continue
       if (!byGroup[group]) byGroup[group] = []
       byGroup[group].push(row)
     }
-    return Object.entries(byGroup)
-      .flatMap(([group, groupRows]) => {
-        const sorted = [...groupRows]
-          .sort((a, b) =>
+    const sortedByGroup = Object.entries(byGroup).map(
+      ([group, groupRows]) =>
+        [
+          group,
+          [...groupRows].sort((a, b) =>
             String(a.time_period ?? '').localeCompare(
               String(b.time_period ?? ''),
             ),
-          )
-          .filter((row) => row[metricConfig.metricId] != null)
-        if (sorted.length === 0) return []
-        const points =
-          sorted.length === 1
-            ? [sorted[0]]
-            : [sorted[0], sorted[sorted.length - 1]]
-        return points.map(
-          (row) =>
-            `- ${group} (${row.time_period}): ${row[metricConfig.metricId]} ${metricConfig.shortLabel}`,
+          ),
+        ] as const,
+    )
+
+    const formatPoint = (group: string, row: HetRow) =>
+      `- ${group} (${row.time_period}): ${row[metricConfig.metricId]} ${metricConfig.shortLabel}`
+
+    // Every Nth point per group, by index so it works for both annual and
+    // monthly cadences, always keeping the group's true first and last point
+    // so the overall trend arc is never lost even when thinned.
+    const thinToStep = (sorted: HetRow[], step: number) => {
+      if (step <= 1 || sorted.length <= 2) return sorted
+      const thinned = sorted.filter((_, i) => i % step === 0)
+      if (thinned[thinned.length - 1] !== sorted[sorted.length - 1]) {
+        thinned.push(sorted[sorted.length - 1])
+      }
+      return thinned
+    }
+
+    const render = (step: number) =>
+      sortedByGroup
+        .flatMap(([group, sorted]) =>
+          thinToStep(sorted, step).map((row) => formatPoint(group, row)),
         )
-      })
-      .join('\n')
+        .join('\n')
+
+    // Send the full per-year (or per-month) series when it's small enough for
+    // the model to work with the whole trend, since that's a materially
+    // better answer than two endpoints. Only thin when the full series would
+    // blow past a reasonable prompt budget, stepping up until it fits.
+    const full = render(1)
+    if (new TextEncoder().encode(full).length <= TIME_SERIES_TARGET_BYTES) {
+      return full
+    }
+    let step = 2
+    let thinned = render(step)
+    while (
+      new TextEncoder().encode(thinned).length > TIME_SERIES_TARGET_BYTES &&
+      step < 100
+    ) {
+      step++
+      thinned = render(step)
+    }
+    return thinned
   }
 
   // For population-vs-distribution, include both the outcome share and
@@ -103,17 +148,37 @@ export function formatDataRows(
       ? metricConfig.populationComparisonMetric
       : null
 
-  return rows
-    .filter((row) => {
-      // Maps always have a place name; other charts key off the demographic group.
-      const hasLabel = isMap
-        ? row.fips_name != null
-        : row[demographicType] != null
-      if (!hasLabel || row[metricConfig.metricId] == null) return false
-      if (groupFilter && !groupFilter.has(String(row[demographicType])))
-        return false
-      return true
-    })
+  const filteredRows = rows.filter((row) => {
+    // Maps always have a place name; other charts key off the demographic group.
+    const hasLabel = isMap
+      ? row.fips_name != null
+      : row[demographicType] != null
+    if (!hasLabel || row[metricConfig.metricId] == null) return false
+    if (groupFilter && !groupFilter.has(String(row[demographicType])))
+      return false
+    return true
+  })
+
+  // A map showing 2+ places is a real geographic comparison, so default to
+  // the group on screen. A map showing fewer than 2 places (a single county
+  // or state, with no children to compare) has nothing geographic to gain
+  // from filtering, so fall back to every group within that one place.
+  const distinctPlaces = isMap
+    ? new Set(filteredRows.map((row) => row.fips_name)).size
+    : 0
+  const activeRows =
+    isMap &&
+    activeDemographicGroup &&
+    activeDemographicGroup !== ALL &&
+    distinctPlaces >= 2
+      ? filteredRows.filter(
+          (row) =>
+            String(row[demographicType]) === activeDemographicGroup ||
+            String(row[demographicType]) === ALL,
+        )
+      : filteredRows
+
+  return activeRows
     .map((row) => {
       // On a map, label each row with BOTH its place and demographic group so
       // the model can read either a geographic gap (across places) or a
@@ -340,7 +405,8 @@ export interface InsightPeerConfig {
 // Optional context about which groups the user has focused the chart on.
 export interface InsightContext {
   // The demographic group currently highlighted on a map (e.g. the active
-  // choropleth group). Used only to steer the prompt, not to filter rows.
+  // choropleth group). Steers the prompt wording, and on a multi-place map
+  // also filters the data to that group (see formatDataRows).
   activeDemographicGroup?: DemographicGroup
   // The subset of groups the user has selected (e.g. via the trend legend).
   // Filters the rows the model sees so the insight matches what is on screen.
@@ -379,6 +445,7 @@ export function prepareInsightData(
   demographicType: DemographicType,
   queryResponses?: MetricQueryResponse[],
   selectedGroups?: DemographicGroup[],
+  activeDemographicGroup?: DemographicGroup,
 ): InsightData {
   let dataSection = ''
   if (queryResponses?.[0]) {
@@ -391,6 +458,7 @@ export function prepareInsightData(
         demographicType,
         metricConfig,
         selectedGroups,
+        activeDemographicGroup,
       )
     }
   }
@@ -420,6 +488,7 @@ export function getInsightDataStatus(
   // region-self query). Gates the peer fallback so a lone subgroup row — with no
   // overall rate — stays hidden rather than being ranked as the region's overall.
   regionHasAllRate = false,
+  activeDemographicGroup?: DemographicGroup,
 ): InsightDataStatus {
   const { entryCount } = prepareInsightData(
     hashId,
@@ -427,6 +496,7 @@ export function getInsightDataStatus(
     demographicType,
     queryResponses,
     selectedGroups,
+    activeDemographicGroup,
   )
   if (entryCount >= 2) return 'multi'
   if (MAP_CHART_IDS.includes(hashId) && regionHasAllRate) return 'single-region'
@@ -452,6 +522,7 @@ export async function generateCardInsight(
     demographicType,
     queryResponses,
     context?.selectedGroups,
+    context?.activeDemographicGroup,
   )
 
   // Single-region map: rank the region against its same-level peers instead of

--- a/server/insight_budget.go
+++ b/server/insight_budget.go
@@ -18,11 +18,11 @@ import (
 )
 
 const (
-	// Sized for the largest realistic single query today: a full county-level
-	// map crossed with every demographic group (e.g. all 254 Texas counties x 9
-	// race/ethnicity groups runs ~130-180KB). A follow-up that thins map and
-	// time-series prompts client-side will let this come back down.
-	insightPromptMaxBytes = 200 * 1024
+	// Client-side group-filtering and time-series thinning keep even the
+	// largest map or compare-mode prompt well under this; measured
+	// compare-mode contrast prompts (two data sections in one request) run
+	// ~11-17KB.
+	insightPromptMaxBytes = 30 * 1024
 	killSwitchObject      = "insights-generation-disabled"
 	killSwitchTTL         = 60 * time.Second
 	ledgerCASAttempts     = 5


### PR DESCRIPTION
## Summary

Follow-up to #5048: thins map and time-series insight prompts client-side so the server-side size cap can come down from the generous placeholder in that PR to a value that reflects normal prompt sizes.

- Group-filtering: a multi-place map insight defaults to only the actively highlighted demographic group's rows across places (plus each place's "All" baseline row), instead of every group for every place. Removes the bulk of rows in the common case (e.g. a full-state county map crossed with every race/ethnicity group).
- Time-series thinning: sends the full per-year/month series when it fits a per-side byte budget; otherwise thins by index step while always keeping each group's true first and last point, so trend direction and current value are never lost.
- Lowers `insightPromptMaxBytes` from 200KB (the untrimmed-data cap from #5048) to 30KB, sized for measured compare-mode contrast prompts (~11-17KB, the largest case since it carries two data sections in one request).

Right-sizing the budget per context (single card vs. report-wide vs. compare mode) is tracked separately in #5046 — this PR uses one shared, conservative budget.

## Test plan

- [x] `generateVisualizationInsight.test.ts`: 39 tests covering group-filtering (multi-place vs. single-place, active-group selection, "All" row retention) and time-series thinning (under-budget passthrough, step-thinning, first/last point retention)
- [x] TypeScript type-checks with no errors
- [x] Go server builds and tests pass

## Depends on

#5048 — this PR is based on that branch and should merge after it.
